### PR TITLE
fix: main content does not overlap with top right corner buttons on narrow screens

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -73,6 +73,9 @@ body {
 }
 
 /* Main page elements */
+.main-content {
+    padding-right: 100px;
+}
 .searchbutton {
     margin-top: 20px;
 }

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -13,7 +13,7 @@ const Layout: React.FC<LayoutProps> = ({ children }) => {
         <LoginStatus />
         <ThemeToggle />
       </div>
-      <div>{children}</div>
+      <div className="main-content">{children}</div>
     </div>
   );
 };


### PR DESCRIPTION
Adds right padding to main content so that when the screen is narrow (e.g. on mobile), it dynamically wraps to avoid overlap with top right corner buttons.

### before 

Wide: 

<img width="634" alt="Screenshot 2025-02-17 at 11 54 15 PM" src="https://github.com/user-attachments/assets/621e9b5d-e690-4ab2-b8f5-39312e33aaa6" />

Narrow:

<img width="511" alt="Screenshot 2025-02-17 at 11 54 05 PM" src="https://github.com/user-attachments/assets/60738d74-0eef-45e0-9ed7-9c0d46af020d" />


### after

Wide: unchanged

<img width="634" alt="Screenshot 2025-02-17 at 11 54 15 PM" src="https://github.com/user-attachments/assets/2881d896-4858-4ad9-a824-c444d09e542a" />

Narrow: fixed

<img width="508" alt="Screenshot 2025-02-17 at 11 52 07 PM" src="https://github.com/user-attachments/assets/0ace99ae-2c86-4754-9184-c64bf3d62e56" />
